### PR TITLE
Fixed up the issues in the wiki extraction tools.

### DIFF
--- a/extraction_tools_wiki/extract_wiki_data.py
+++ b/extraction_tools_wiki/extract_wiki_data.py
@@ -103,7 +103,7 @@ if __name__ == "__main__":
 
     # Determine page titles count
     page_titles_total = len(wiki_page_titles)
-    print(">>> Number of extracted wiki pages: %d" % page_titles_total)
+    print(f">>> Number of extracted wiki pages: {page_titles_total:d}")
 
     # STAGE TWO: EXTRACT WIKI USING PAGE TITLES
 
@@ -116,9 +116,7 @@ if __name__ == "__main__":
     page_titles_count = 1
     print(">>> Starting wiki text extraction for extracted page titles...")
     for page_title, page_revision_date in wiki_page_titles.page_titles.items():
-        print("  > Progress: %s of %s - Processing: %s" % ('{:4d}'.format(page_titles_count),
-                                                           '{:4d}'.format(page_titles_total),
-                                                           page_title))
+        print(f"  > Progress: {page_titles_count:4d} of {page_titles_total:4d} - Processing: {page_title}")
 
         # Convert revision date to datetime object
         last_revision_date = datetime.datetime.strptime(wiki_page_titles[page_title],

--- a/extraction_tools_wiki/extract_wiki_data.py
+++ b/extraction_tools_wiki/extract_wiki_data.py
@@ -28,106 +28,116 @@ import os
 import sys
 import json
 import datetime
+import itertools
 
-from .wiki_page_titles import WikiPageTitles
-from .wiki_page_text import WikiPageText
+from extraction_tools_wiki.wiki_page_titles import WikiPageTitles
+from extraction_tools_wiki.wiki_page_text import WikiPageText
 
+
+OSRS_WIKI_API_URL = "https://oldschool.runescape.wiki/api.php"
 
 if __name__ == "__main__":
     import argparse
-    AP = argparse.ArgumentParser()
-    AP.add_argument("-c",
+    ap = argparse.ArgumentParser()
+    ap.add_argument("-c",
                     "--categories",
                     nargs="+",
                     help="<Required> List of OSRS Wiki categories to extract",
                     required=True)
-    ARGS = vars(AP.parse_args())
+    args = vars(ap.parse_args())
 
     # List of categories to process from the OSRS Wiki
-    TARGET_CATEGORIES = ARGS["categories"]
+    target_categories = args["categories"]
     # The first category argument, used to build the output file name
-    PRIMARY_CATEGORY = TARGET_CATEGORIES[0].lower()
+    primary_category = target_categories[0].lower()
 
     # Specify the name for the page titles output JSON file
-    TITLES_FILE_NAME = "extract_page_titles_" + PRIMARY_CATEGORY + ".json"
-    TITLES_FILE_PATH = os.path.join("extraction_tools_wiki", TITLES_FILE_NAME)
+    titles_file_name = f"extract_page_titles_{primary_category}.json"
+    titles_file_path = os.path.join("extraction_tools_wiki", titles_file_name)
 
     # Specify the name for the wiki text output JSON file
-    TEXT_FILE_NAME = "extract_page_text_" + PRIMARY_CATEGORY + ".json"
-    TEXT_FILE_PATH = os.path.join("extraction_tools_wiki", TEXT_FILE_NAME)
+    text_file_name = f"extract_page_text_{primary_category}.json"
+    text_file_path = os.path.join("extraction_tools_wiki", text_file_name)
 
     # STAGE ZERO: SET SCRIPT CONFIGURATION
 
     # Specify the custom user agent for all requests
-    USER_AGENT = "some-agent"
-    USER_EMAIL = "name@domain.com"
+    user_agent = "some-agent"
+    user_email = "name@domain.com"
 
     # Boolean to trigger load page titles from file, or run fresh page title extraction
-    LOAD_FILES = False
+    load_files = True
 
     # Set the revision date, extract wiki pages only after this date
-    LAST_EXTRACTION_DATE = datetime.datetime.strptime("2019-01-29T00:00:00Z",
+    last_extraction_date = datetime.datetime.strptime("2019-01-28T00:00:00Z",
                                                       '%Y-%m-%dT%H:%M:%SZ')
 
     # STAGE ONE: EXTRACT PAGE TITLES
 
     print(">>> Starting wiki page titles extraction...")
     # Create object to handle page titles extraction
-    WIKI_PAGE_TITLES = WikiPageTitles(TARGET_CATEGORIES,
-                                      TITLES_FILE_PATH,
-                                      USER_AGENT,
-                                      USER_EMAIL)
+    wiki_page_titles = WikiPageTitles(OSRS_WIKI_API_URL,
+                                      target_categories,
+                                      user_agent,
+                                      user_email)
 
     # Load previously extracted page titles from JSON, or extract from OSRS Wiki API
-    if LOAD_FILES:
-        LOADED_PAGE_TITLES = WIKI_PAGE_TITLES.load_page_titles()
-        if not LOADED_PAGE_TITLES:
-            print(">>> ERROR: Specified page titles to load, but not file found...")
-            print(">>> EXITING.")
-            sys.exit(1)
+    if load_files:
+        loaded_page_titles = wiki_page_titles.load_page_titles(titles_file_path)
+        if not loaded_page_titles:
+            sys.exit(">>> ERROR: Specified page titles to load, but not file found. Exiting.")
     else:
-        WIKI_PAGE_TITLES.extract_page_titles()
-        WIKI_PAGE_TITLES.extract_last_revision_timestamp()
-        WIKI_PAGE_TITLES.export_page_titles_in_json()
+        # Extract page titles using supplied categories
+        wiki_page_titles.extract_page_titles()
+        # Extract page revision date
+        # Loop 50 page titles at a time, the max number for a revisions request using page titles
+        for page_title_list in itertools.zip_longest(*[iter(wiki_page_titles.page_titles)] * 50):
+            # Remove None entries from the list of page titles
+            page_title_list = filter(None, page_title_list)
+            # Join the page titles list using the pipe (|) separator
+            page_titles_string = "|".join(page_title_list)
+            # Extract the page revision date
+            wiki_page_titles.extract_last_revision_timestamp(page_titles_string)
+        # Save all page titles and
+        wiki_page_titles.export_page_titles_in_json(titles_file_path)
 
     # Determine page titles count
-    PAGE_TITLES_TOTAL = len(WIKI_PAGE_TITLES.page_titles)
-    print(">>> Number of extracted wiki pages: %d" % PAGE_TITLES_TOTAL)
+    page_titles_total = len(wiki_page_titles)
+    print(">>> Number of extracted wiki pages: %d" % page_titles_total)
 
     # STAGE TWO: EXTRACT WIKI USING PAGE TITLES
 
     # Open page title JSON file, to check if page needs to have wiki text extracted
-    JSON_DATA = dict()
-    if os.path.isfile(TEXT_FILE_PATH):
-        with open(TEXT_FILE_PATH, mode='r') as existing_out_file:
-            JSON_DATA = json.load(existing_out_file)
+    json_data = dict()
+    if os.path.isfile(text_file_path):
+        with open(text_file_path, mode='r') as existing_out_file:
+            json_data = json.load(existing_out_file)
 
-    PAGE_TITLES_COUNT = 1
+    page_titles_count = 1
     print(">>> Starting wiki text extraction for extracted page titles...")
-    for page_title, page_revision_date in WIKI_PAGE_TITLES.page_titles.items():
-        print("  > Progress: %s of %s - Processing: %s" % ('{:4d}'.format(PAGE_TITLES_COUNT),
-                                                           '{:4d}'.format(PAGE_TITLES_TOTAL),
+    for page_title, page_revision_date in wiki_page_titles.page_titles.items():
+        print("  > Progress: %s of %s - Processing: %s" % ('{:4d}'.format(page_titles_count),
+                                                           '{:4d}'.format(page_titles_total),
                                                            page_title))
 
         # Convert revision date to datetime object
-        last_revision_date = datetime.datetime.strptime(WIKI_PAGE_TITLES.page_titles[page_title],
+        last_revision_date = datetime.datetime.strptime(wiki_page_titles[page_title],
                                                         '%Y-%m-%dT%H:%M:%SZ')
 
         # Check if page title is already present in JSON output file, also check revision date
-        if page_title in JSON_DATA:
-            if last_revision_date < LAST_EXTRACTION_DATE:
-                # If the last revision was before last extract, skip
-                PAGE_TITLES_COUNT += 1
-                continue
+        if page_title in json_data and last_revision_date < last_extraction_date:
+            # If the last revision was before last extract, skip
+            page_titles_count += 1
+            continue
 
         # Create object to extract page wiki text
-        wiki_page_text = WikiPageText(page_title,
-                                      TEXT_FILE_PATH,
-                                      USER_AGENT,
-                                      USER_EMAIL)
+        wiki_page_text = WikiPageText(OSRS_WIKI_API_URL,
+                                      page_title,
+                                      user_agent,
+                                      user_email)
 
         # If the page title has not been extracted, extract wiki text and save to JSON file
         wiki_page_text.extract_page_wiki_text()
-        wiki_page_text.export_wiki_text_to_json()
+        wiki_page_text.export_wiki_text_to_json(text_file_path)
 
-        PAGE_TITLES_COUNT += 1
+        page_titles_count += 1

--- a/extraction_tools_wiki/wiki_page_text.py
+++ b/extraction_tools_wiki/wiki_page_text.py
@@ -20,7 +20,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 import os
-import sys
 import json
 import logging
 import requests
@@ -52,11 +51,12 @@ class WikiPageText:
         API and extract the wiki text for a specific page. The page to query is
         determined by the page title.
         """
-        request = dict()
-        request['action'] = 'parse'
-        request['prop'] = 'wikitext'
-        request['format'] = 'json'
-        request['page'] = self.page_title
+        request = {
+            "action": "parse",
+            "prop": "wikitext",
+            "format": "json",
+            "page": self.page_title
+        }
 
         # Perform HTTP GET request
         try:
@@ -64,8 +64,7 @@ class WikiPageText:
                                      headers=self.custom_agent,
                                      params=request).json()
         except requests.exceptions.RequestException as e:
-            print(e)
-            sys.exit(">>> ERROR: Get request error. Exiting.")
+            raise SystemExit(">>> ERROR: Get request error. Exiting.") from e
 
         try:
             # Try to extract the wiki text from the HTTP response

--- a/extraction_tools_wiki/wiki_page_text.py
+++ b/extraction_tools_wiki/wiki_page_text.py
@@ -20,6 +20,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 import os
+import sys
 import json
 import logging
 import requests
@@ -30,15 +31,14 @@ LOG = logging.getLogger(__name__)
 class WikiPageText:
     """This class handles extraction of wiki text using an OSRS Wiki API query.
 
-    :param str page_title: OSRS Wiki page titles used for API query.
-    :param str out_file_name: The file name used for exporting the wiki text to JSON.
-    :param str user_agent: A custom user-agent name to be used for the API request.
-    :param str user_email: A custom user-agent email to be used for the API request.
+    :param base_url: The OSRS Wiki URL used for API queries.
+    :param page_title: OSRS Wiki page titles used for API query.
+    :param user_agent: A custom user-agent name to be used for the API request.
+    :param user_email: A custom user-agent email to be used for the API request.
     """
-    def __init__(self, page_title, out_file_name, user_agent, user_email):
-        self.base_url = "https://oldschool.runescape.wiki/api.php"
+    def __init__(self, base_url: str, page_title: str, user_agent: str, user_email: str):
+        self.base_url = base_url
         self.page_title = page_title
-        self.out_file_name = out_file_name
         self.custom_agent = {
             'User-Agent': user_agent,
             'From': user_email
@@ -46,7 +46,7 @@ class WikiPageText:
         self.wiki_text = None
 
     def extract_page_wiki_text(self):
-        """Extract wikitext from OSRS Wiki for a provided page name.
+        """Extract wiki text from OSRS Wiki for a provided page name.
 
         This function uses the class attributes as input to query the OSRS Wiki
         API and extract the wiki text for a specific page. The page to query is
@@ -58,37 +58,44 @@ class WikiPageText:
         request['format'] = 'json'
         request['page'] = self.page_title
 
-        page_data = requests.get(self.base_url,
-                                 headers=self.custom_agent,
-                                 params=request).json()
+        # Perform HTTP GET request
+        try:
+            page_data = requests.get(self.base_url,
+                                     headers=self.custom_agent,
+                                     params=request).json()
+        except requests.exceptions.RequestException as e:
+            print(e)
+            sys.exit(">>> ERROR: Get request error. Exiting.")
 
         try:
-            # Try to extract the wikitext from the HTTP response
+            # Try to extract the wiki text from the HTTP response
             wiki_text = page_data["parse"]["wikitext"]["*"].encode("utf-8")
         except KeyError:
-            # Set to None if wikitext extraction failed
+            # Set to None if wiki text extraction failed
             wiki_text = None
 
         self.wiki_text = wiki_text
 
-    def export_wiki_text_to_json(self):
+    def export_wiki_text_to_json(self, out_file_name: str):
         """Export all extracted wiki text to a JSON file.
 
         Querying the OSRS Wiki constantly is a bad approach. This function writes any
         extracted wiki text to a file to save re-querying the API. This function
         attempts to overwrite pre-existing wiki text entry in a file, where the key
         is the page title, and the value is the wiki text.
+
+        :param out_file_name: The file name to save wiki text to.
         """
         # Create dictionary for export
         json_data = {self.page_title: str(self.wiki_text)}
 
         # Write dictionary to JSON file
-        if not os.path.isfile(self.out_file_name):
-            with open(self.out_file_name, mode='w') as out_file:
+        if not os.path.isfile(out_file_name):
+            with open(out_file_name, mode='w') as out_file:
                 out_file.write(json.dumps(json_data, indent=4))
         else:
-            with open(self.out_file_name) as feeds_json:
+            with open(out_file_name) as feeds_json:
                 feeds = json.load(feeds_json)
             feeds[self.page_title] = str(self.wiki_text)
-            with open(self.out_file_name, mode='w') as out_file:
+            with open(out_file_name, mode='w') as out_file:
                 out_file.write(json.dumps(feeds, indent=4))

--- a/extraction_tools_wiki/wiki_page_titles.py
+++ b/extraction_tools_wiki/wiki_page_titles.py
@@ -22,6 +22,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 import os
 import json
 import logging
+from typing import Dict
 import requests
 
 LOG = logging.getLogger(__name__)
@@ -117,7 +118,7 @@ class WikiPageTitles:
                 # Log the page title, and append to list
                 self.page_titles[page_title] = None
 
-    def _extract_page_titles_from_category_callback(self, request: dict, category: str):
+    def _extract_page_titles_from_category_callback(self, request: Dict, category: str):
         """Query callback function for OSRS Wiki category query.
 
         A callback function for using MediaWiki generators. Since the category query is a
@@ -132,7 +133,7 @@ class WikiPageTitles:
         request['format'] = 'json'
         request['cmlimit'] = '500'
 
-        last_continue = {}  # type: dict
+        last_continue = {}
 
         while True:
             # Clone original request
@@ -166,7 +167,7 @@ class WikiPageTitles:
             # Update the last fetched page title to continue query
             last_continue = result['continue']
 
-    def extract_last_revision_timestamp(self, page_titles_string: str) -> dict:
+    def extract_last_revision_timestamp(self, page_titles_string: str) -> Dict:
         """Extract the last revision timestamp for page titles from OSRS Wiki.
 
         The MediaWiki API used by the OSRS Wiki has the functionality to return the

--- a/extraction_tools_wiki/wiki_page_titles.py
+++ b/extraction_tools_wiki/wiki_page_titles.py
@@ -20,7 +20,6 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 import os
-import sys
 import json
 import logging
 import requests
@@ -43,26 +42,24 @@ class WikiPageTitles:
             'User-Agent': user_agent,
             'From': user_email
         }
-        self.page_titles = dict()  # type: dict
+        self.page_titles: Dict[str, str] = dict()
 
-    def __iter__(self):
+    def __iter__(self) -> str:
         """Iterate (loop) over the extracted or loaded OSRS Wiki page titles.
 
         :return: An extracted page title from the OSRS Wiki for a specific category.
-        :rtype: str
         """
         for page_title in self.page_titles:
             yield page_title
 
-    def __len__(self):
+    def __len__(self) -> int:
         """Return the length of the extract or loaded OSRS Wiki page titles.
 
         :return: The number of extracted or loaded page titles.
-        :rtype int:
         """
         return len(self.page_titles)
 
-    def __getitem__(self, key: str):
+    def __getitem__(self, key: str) -> str:
         """Return the revision date of the provided page title.
 
         :param key: The page title to extract the revision date from.
@@ -71,7 +68,7 @@ class WikiPageTitles:
         """
         return self.page_titles[key]
 
-    def load_page_titles(self, in_file_name: str):
+    def load_page_titles(self, in_file_name: str) -> bool:
         """Load a JSON file of OSRS Wiki page titles that have previously been extracted.
 
         If you already have a recently dumped JSON file of OSRS Wiki page titles you
@@ -80,7 +77,6 @@ class WikiPageTitles:
 
         :param in_file_name: The name of the file to load page titles from.
         :return: A boolean to indicate if a file with page titles was loaded correctly.
-        :rtype: bool
         """
         if not os.path.isfile(in_file_name):
             return False
@@ -151,8 +147,7 @@ class WikiPageTitles:
                                       headers=self.custom_agent,
                                       params=req).json()
             except requests.exceptions.RequestException as e:
-                print(e)
-                sys.exit(">>> ERROR: Get request error. Exiting.")
+                raise SystemExit(">>> ERROR: Get request error. Exiting.") from e
 
             # Handle HTTP response
             if 'query' in result:
@@ -171,7 +166,7 @@ class WikiPageTitles:
             # Update the last fetched page title to continue query
             last_continue = result['continue']
 
-    def extract_last_revision_timestamp(self, page_titles_string: str):
+    def extract_last_revision_timestamp(self, page_titles_string: str) -> dict:
         """Extract the last revision timestamp for page titles from OSRS Wiki.
 
         The MediaWiki API used by the OSRS Wiki has the functionality to return the
@@ -183,7 +178,6 @@ class WikiPageTitles:
 
         :param page_titles_string: A string of pipe separated wiki page titles.
         :return pages_revision_data:
-        :rtype dict:
         """
         # Construct query for fetching page revisions
         request = {

--- a/extraction_tools_wiki/wiki_page_titles.py
+++ b/extraction_tools_wiki/wiki_page_titles.py
@@ -20,9 +20,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 import os
+import sys
 import json
 import logging
-import itertools
 import requests
 
 LOG = logging.getLogger(__name__)
@@ -31,20 +31,19 @@ LOG = logging.getLogger(__name__)
 class WikiPageTitles:
     """This class handles extraction of wiki page titles by category using an OSRS Wiki API query.
 
-    :param :obj:`list` of :obj:`str` categories: A list of OSRS Wiki categories.
-    :param str out_file_name: The file name used for exporting the wiki page titles to JSON.
-    :param str user_agent: A custom user-agent name to be used for the API request.
-    :param str user_email: A custom user-agent email to be used for the API request.
+    :param base_url: The OSRS Wiki URL used for API queries.
+    :param categories: A list of OSRS Wiki categories.
+    :param user_agent: A custom user-agent name to be used for the API request.
+    :param user_email: A custom user-agent email to be used for the API request.
     """
-    def __init__(self, categories, out_file_name, user_agent, user_email):
-        self.base_url = "https://oldschool.runescape.wiki/api.php"
-        self.page_titles = dict()
+    def __init__(self, base_url: str, categories: list, user_agent: str, user_email: str):
+        self.base_url = base_url
         self.categories = categories
-        self.out_file_name = out_file_name
         self.custom_agent = {
             'User-Agent': user_agent,
             'From': user_email
         }
+        self.page_titles = dict()  # type: dict
 
     def __iter__(self):
         """Iterate (loop) over the extracted or loaded OSRS Wiki page titles.
@@ -55,19 +54,37 @@ class WikiPageTitles:
         for page_title in self.page_titles:
             yield page_title
 
-    def load_page_titles(self):
+    def __len__(self):
+        """Return the length of the extract or loaded OSRS Wiki page titles.
+
+        :return: The number of extracted or loaded page titles.
+        :rtype int:
+        """
+        return len(self.page_titles)
+
+    def __getitem__(self, key: str):
+        """Return the revision date of the provided page title.
+
+        :param key: The page title to extract the revision date from.
+        :return last_revision_date: The date the page was last modified in a string ISO8601 format.
+        :rtype str:
+        """
+        return self.page_titles[key]
+
+    def load_page_titles(self, in_file_name: str):
         """Load a JSON file of OSRS Wiki page titles that have previously been extracted.
 
         If you already have a recently dumped JSON file of OSRS Wiki page titles you
         can load them using this function. This saves performing additional wiki API
         queries when you have an up-to-date list of page titles.
 
+        :param in_file_name: The name of the file to load page titles from.
         :return: A boolean to indicate if a file with page titles was loaded correctly.
         :rtype: bool
         """
-        if not os.path.isfile(self.out_file_name):
+        if not os.path.isfile(in_file_name):
             return False
-        with open(self.out_file_name) as input_json_file:
+        with open(in_file_name) as input_json_file:
             self.page_titles = json.load(input_json_file)
             return True
 
@@ -80,16 +97,16 @@ class WikiPageTitles:
         `Items, Pets, Furniture`.
         """
         for category in self.categories:
-            self._extract_page_titles_from_category(category)
+            self.extract_page_titles_from_category(category)
 
-    def _extract_page_titles_from_category(self, category):
+    def extract_page_titles_from_category(self, category: str):
         """Query a specific category in the OSRS Wiki and populate a list of page tiles.
 
         A function to extract all page titles from a provided OSRS Wiki category. The
         extracted page title is useful to perform additional API queries, such as
         extracting wiki text or revision timestamps.
 
-        :param str category: A string representing the OSRS Wiki category to extract.
+        :param category: A string representing the OSRS Wiki category to extract.
         """
         # Start construct MediaWiki request
         request = {'list': 'categorymembers'}
@@ -104,21 +121,22 @@ class WikiPageTitles:
                 # Log the page title, and append to list
                 self.page_titles[page_title] = None
 
-    def _extract_page_titles_from_category_callback(self, request, category):
+    def _extract_page_titles_from_category_callback(self, request: dict, category: str):
         """Query callback function for OSRS Wiki category query.
 
         A callback function for using MediaWiki generators. Since the category query is a
         list function, you can use a generator to continue queries when the returned data
         is longer than the maximum returned query.
 
-        :param dict request: A dictionary to be populated with the OSRS Wiki API request.
-        :param str category: A string representing the OSRS Wiki category to extract.
+        :param request: A dictionary to be populated with the OSRS Wiki API request.
+        :param category: A string representing the OSRS Wiki category to extract.
         """
         request['cmtitle'] = 'Category:' + category
         request['action'] = 'query'
         request['format'] = 'json'
         request['cmlimit'] = '500'
-        last_continue = dict()
+
+        last_continue = {}  # type: dict
 
         while True:
             # Clone original request
@@ -128,9 +146,13 @@ class WikiPageTitles:
             req.update(last_continue)
 
             # Perform HTTP GET request
-            result = requests.get(self.base_url,
-                                  headers=self.custom_agent,
-                                  params=req).json()
+            try:
+                result = requests.get(self.base_url,
+                                      headers=self.custom_agent,
+                                      params=req).json()
+            except requests.exceptions.RequestException as e:
+                print(e)
+                sys.exit(">>> ERROR: Get request error. Exiting.")
 
             # Handle HTTP response
             if 'query' in result:
@@ -146,55 +168,61 @@ class WikiPageTitles:
                 print(result['warnings'])
                 break
 
-            # Update the page to continue query
+            # Update the last fetched page title to continue query
             last_continue = result['continue']
 
-    def extract_last_revision_timestamp(self):
-        """Extract the last revision timestamp for all page titles from OSRS Wiki.
+    def extract_last_revision_timestamp(self, page_titles_string: str):
+        """Extract the last revision timestamp for page titles from OSRS Wiki.
 
         The MediaWiki API used by the OSRS Wiki has the functionality to return the
         last revision date of a specific page. This function extracts the revision date
-        for all the extracted page titles. This value can be used to determine if
+        for a list of extracted page titles. This value can be used to determine if
         changes have recently been made to the page, and if the page should be processed
-        again.
+        again. The input page_titles_string needs to be a list of page titles separated
+        by the pipe (|) character. The maximum number of page titles is 50 per API query.
+
+        :param page_titles_string: A string of pipe separated wiki page titles.
+        :return pages_revision_data:
+        :rtype dict:
         """
-        # Loop 50 page titles at a time, the max number for a revisions request using page titles
-        for block_list in itertools.zip_longest(*[iter(self.page_titles)] * 50):
-            # Remove None entries from the list of page titles
-            block_list = filter(None, block_list)
+        # Construct query for fetching page revisions
+        request = {
+            'action': 'query',
+            'prop': 'revisions',
+            'titles': page_titles_string,
+            'format': 'json',
+            'rvprop': 'timestamp'
+        }
 
-            # Join page titles for API query in required format
-            page_titles_string = "|".join(block_list)
+        page_data = requests.get(self.base_url,
+                                 headers=self.custom_agent,
+                                 params=request).json()
 
-            # Construct query for fetching page revisions
-            request = dict()
-            request['action'] = 'query'
-            request['prop'] = 'revisions'
-            request['titles'] = page_titles_string
-            request['format'] = 'json'
-            request['rvprop'] = 'timestamp'
+        # Loop returned page revision data
+        pages_revision_data = page_data["query"]["pages"]
+        for page_id in pages_revision_data:
+            # Extract page title from the response
+            page_title = pages_revision_data[page_id]["title"]
+            # Extract last revision timestamp (ISO 8601 format)
+            page_revision_date = pages_revision_data[page_id]["revisions"][0]["timestamp"]
+            # Add revision date to page_titles dict
+            self.page_titles[page_title] = page_revision_date
 
-            page_data = requests.get(self.base_url,
-                                     headers=self.custom_agent,
-                                     params=request).json()
+        return pages_revision_data
 
-            # Loop returned page revision data
-            pages = page_data["query"]["pages"]
-            for page_id in pages:
-                # Extract page title from the response
-                page_title = pages[page_id]["title"]
-                # Extract last revision timestamp (ISO 8601 format)
-                page_revision_date = pages[page_id]["revisions"][0]["timestamp"]
-                # Add revision date to page_titles dict
-                self.page_titles[page_title] = page_revision_date
+    def export_page_titles_in_json(self, out_file_name: str):
+        """Export all extracted page titles and revision timestamp to a JSON file.
 
-    def export_page_titles_in_json(self):
-        """Export all extracted page titles and revision timestamp to a JSON file."""
-        with open(self.out_file_name, mode='w') as out_file:
+        :param out_file_name: The file name used for exporting the wiki page titles to JSON.
+        """
+        with open(out_file_name, mode='w') as out_file:
             out_file.write(json.dumps(self.page_titles, indent=4))
 
-    def export_page_titles_in_text(self):
-        """Export all extracted page titles from a category to a text file."""
-        with open(self.out_file_name, mode='w', newline='\n') as out_file:
+    def export_page_titles_in_text(self, out_file_name: str):
+        """Export all extracted page titles from a category to a text file.
+
+        :param out_file_name: The file name used for exporting the wiki page titles to a text file.
+        """
+        with open(out_file_name, mode='w', newline='\n') as out_file:
             for page_title in self.page_titles:
                 out_file.write(page_title + '\n')


### PR DESCRIPTION
Fixed the wiki extraction issues documented in #27. 

- Added typing system to both classes
- Modified UPPER_CASE variables (`pylint` lead me astray!)
- Changed relative to absolute imports
- Added format strings where I could see the use
- Fixed `sys.exit()` - but looking at comments should have `raise`d it
- Added some parameters to functions where use outside the `extract_wiki_data.py` script could be useful to other users
