### PR TITLE
Initial development of items_api test for attribute types.

### DIFF
--- a/test/test_items_api_attribute_types.py
+++ b/test/test_items_api_attribute_types.py
@@ -1,0 +1,58 @@
+"""
+Author:  PH01L
+Email:   phoil@osrsbox.com
+Website: https://www.osrsbox.com
+
+Description:
+Tests for module: osrsbox.items_api.all_items
+
+Copyright (c) 2019, PH01L
+
+###############################################################################
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+###############################################################################
+"""
+
+import pytest
+
+from osrsbox import items_api
+
+ALL_DB_ITEMS = items_api.load()
+
+
+@pytest.mark.parametrize("attribute,expected_type", [
+    ("id", int),
+    ("name", str),
+    ("members", bool),
+    ("tradeable", bool),
+    ("tradeable_on_ge", bool),
+    ("stackable", bool),
+    ("noted", bool),
+    ("noteable", bool),
+    ("linked_id", bool),
+    ("equipable", bool),
+    ("cost", int),
+    ("lowalch", int),
+    ("highalch", int),
+    ("weight", float),
+    ("buy_limit", int),
+    ("quest_item", bool),
+    ("release_date", str),
+    ("examine", str),
+    ("url", str)
+])
+def test_items_api_attribute_type(attribute, expected_type):
+    for item in ALL_DB_ITEMS:
+        item_attr_value = getattr(item, attribute)
+        if item_attr_value is None:
+            continue
+        assert isinstance(item_attr_value, expected_type)


### PR DESCRIPTION
As per comment in #18 - this test performs type checks on all item attributes (EDIT: not including the `item_equipment` class).

The test works, but I think there must be a better way to implement this. The primary problem is the test only identifies the first failed item attribute test. For example:

```
>           assert isinstance(item_attr_value, expected_type)
E           AssertionError: assert False
E            +  where False = isinstance(['Animal Magnetism'], <class 'bool'>)

test\test_items_api_attribute_types.py:58: AssertionError
```

The above is the failed test for the `quest_item` attribute. This fails - but you cannot tell which item is causing the problem. And there are currently 17 items that should fail this test (as documented in #52)

It would be much better if the test could provide a list of items and the problematic item attributes.

The build currently fails as a couple of items do not have correct attribute data types.