### PR TITLE
convert item definition and item equipment to dataclass

### DIFF
--- a/osrsbox/items_api/all_items.py
+++ b/osrsbox/items_api/all_items.py
@@ -45,10 +45,10 @@ class AllItems:
         self.all_items_dict: Dict[int, ItemDefinition] = dict()
         self.load_all_items(input_data_file_or_directory)
 
-    def __iter__(self) -> Generator[str, None, None]:
+    def __iter__(self) -> Generator[ItemDefinition, None, None]:
         """Iterate (loop) over each ItemDefinition object."""
-        for item_id in self.all_items:
-            yield item_id
+        for item in self.all_items:
+            yield item
 
     def __getitem__(self, id_number: int) -> ItemDefinition:
         """Return the item definition object for a loaded item.
@@ -126,7 +126,7 @@ class AllItems:
         """
         # Load the item using the ItemDefinition class
         try:
-            item_def = ItemDefinition(**item_json)
+            item_def = ItemDefinition.from_json(item_json)
         except TypeError as e:
             raise ValueError("Error: Invalid JSON structure found, check supplied input. Exiting") from e
 

--- a/osrsbox/items_api/item_definition.py
+++ b/osrsbox/items_api/item_definition.py
@@ -21,11 +21,13 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import os
 import json
+from dataclasses import dataclass, asdict
 from typing import Dict, Optional
 
 from osrsbox.items_api.item_equipment import ItemEquipment
 
 
+@dataclass
 class ItemDefinition:
     """This class defines the object structure and properties for an OSRS item.
 
@@ -34,54 +36,44 @@ class ItemDefinition:
     Equipable items have additional properties defined in the linked ItemEquipment
     class.
     """
+    id: int
+    name: str
+    members: bool
+    tradeable: Optional[bool]
+    tradeable_on_ge: bool
+    stackable: bool
+    noted: bool
+    noteable: bool
+    linked_id: Optional[int]
+    placeholder: bool
+    equipable: bool
+    equipable_by_player: bool
+    cost: int
+    lowalch: int
+    highalch: int
+    weight: Optional[float]
+    buy_limit: Optional[int]
+    quest_item: Optional[bool]
+    release_date: Optional[str]
+    examine: Optional[str]
+    url: Optional[str]
+    equipment: Optional[ItemEquipment] = None
 
-    def __init__(self, id=None, name=None, members=None, tradeable=None, tradeable_on_ge=None, stackable=None,
-                 noted=None, noteable=None, linked_id=None, placeholder=None, equipable=None, equipable_by_player=None,
-                 cost=None, lowalch=None, highalch=None, weight=None, buy_limit=None, quest_item=None,
-                 release_date=None, examine=None, url=None, equipment=None):
-        self.id = id
-        self.name = name
-        self.members = members
-        self.tradeable = tradeable
-        self.tradeable_on_ge = tradeable_on_ge
-        self.stackable = stackable
-        self.noted = noted
-        self.noteable = noteable
-        self.linked_id = linked_id
-        self.placeholder = placeholder
-        self.equipable = equipable
-        self.equipable_by_player = equipable_by_player
-        self.cost = cost
-        self.lowalch = lowalch
-        self.highalch = highalch
-        self.weight = weight
-        self.buy_limit = buy_limit
-        self.quest_item = quest_item
-        self.release_date = release_date
-        self.examine = examine
-        self.url = url
+    @classmethod
+    def from_json(cls, json_dict: Dict) -> "ItemDefinition":
+        """Convert the dictionary under the 'equipment' key into actual :class:`ItemEquipment`"""
+        if json_dict.get("equipable_by_player"):
+            equipment = json_dict.pop("equipment")
+            json_dict["equipment"] = ItemEquipment(**equipment)
 
-        self.equipment: Optional[ItemEquipment] = None
-
-        if self.equipable_by_player:
-            self.equipment = ItemEquipment(**equipment)
+        return cls(**json_dict)
 
     def construct_json(self) -> Dict:
         """Construct dictionary/JSON for exporting or printing.
 
         :return json_out: All class attributes stored in a dictionary.
         """
-        json_out: Dict = dict()
-
-        for prop in self.__dict__:
-            if prop == "equipment":
-                continue
-            json_out[prop] = getattr(self, prop)
-
-        if self.equipable_by_player:
-            json_out["equipment"] = self.equipment.construct_json()
-
-        return json_out
+        return asdict(self)
 
     def export_json(self, pretty: bool, export_path: str):
         """Output Item to JSON file.

--- a/osrsbox/items_api/item_equipment.py
+++ b/osrsbox/items_api/item_equipment.py
@@ -18,10 +18,11 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ###############################################################################
 """
+from dataclasses import dataclass, asdict
+from typing import Dict, Optional
 
-from typing import Dict
 
-
+@dataclass
 class ItemEquipment:
     """This class defines the properties for an equipable OSRS item.
 
@@ -30,36 +31,27 @@ class ItemEquipment:
     additional properties about equipment slot, attack speed and skill requirements
     for the item.
     """
-
-    def __init__(self, attack_stab=None, attack_slash=None, attack_crush=None, attack_magic=None,
-                 attack_ranged=None, defence_stab=None, defence_slash=None, defence_crush=None,
-                 defence_magic=None, defence_ranged=None, melee_strength=None, ranged_strength=None,
-                 magic_damage=None, prayer=None, slot=None, attack_speed=None, requirements=None):
-        self.attack_stab = attack_stab
-        self.attack_slash = attack_slash
-        self.attack_crush = attack_crush
-        self.attack_magic = attack_magic
-        self.attack_ranged = attack_ranged
-        self.defence_stab = defence_stab
-        self.defence_slash = defence_slash
-        self.defence_crush = defence_crush
-        self.defence_magic = defence_magic
-        self.defence_ranged = defence_ranged
-        self.melee_strength = melee_strength
-        self.ranged_strength = ranged_strength
-        self.magic_damage = magic_damage
-        self.prayer = prayer
-        self.slot = slot
-        self.attack_speed = attack_speed
-        self.requirements = requirements
+    attack_stab: int
+    attack_slash: int
+    attack_crush: int
+    attack_magic: int
+    attack_ranged: int
+    defence_stab: int
+    defence_slash: int
+    defence_crush: int
+    defence_magic: int
+    defence_ranged: int
+    melee_strength: int
+    ranged_strength: int
+    magic_damage: int
+    prayer: int
+    slot: Optional[str]
+    attack_speed: Optional[int]
+    requirements: Optional[Dict]
 
     def construct_json(self) -> Dict:
         """Construct dictionary/JSON of item_equipment property for exporting or printing.
 
         :return json_out: A dictionary of all equipment properties.
         """
-        json_out = dict()
-        for prop in self.__dict__:
-            json_out[prop] = getattr(self, prop)
-
-        return json_out
+        return asdict(self)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 certifi==2019.3.9
 chardet==3.0.4
-dataclasses==0.6
 dateparser==0.7.1
 idna==2.8
 mwparserfromhell==0.5.2
@@ -11,3 +10,4 @@ requests==2.21.0
 six==1.12.0
 tzlocal==1.5.1
 urllib3==1.24.1
+dataclasses==0.6; python_version < "3.7"

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ VERSION = "1.1.1"
 
 # Name of any third party packages that are required from the `osrsbox` package.
 REQUIRED = [
+    'dataclasses;python_version<"3.7"'
 ]
 
 # Import the README and use it as the long-description.


### PR DESCRIPTION
Cleans up the existing classes and moves them into dataclasses. I chose to also modify the `construct_json` methods to use `asdict` from the standard lib, but we potentially want to just remove this method in general and just have the caller use `asdict` instead of us handling how the class goes to json. Since its not that big of a deal, to reduce the number of changes I had to make, I converted the code while maintaining those functions APIs.

#56 