### PR TITLE
refactor weapon/item equipment into inherited classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Custom
 .idea/
+.vscode/
 extraction_tools_cache/items/
 extraction_tools_cache/npcs/
 extraction_tools_cache/objects/

--- a/osrsbox/items_api/all_items.py
+++ b/osrsbox/items_api/all_items.py
@@ -27,6 +27,8 @@ from typing import Union
 from typing import Generator
 
 from osrsbox.items_api.item_definition import ItemDefinition
+from osrsbox.items_api.item_weapon import ItemWeapon
+from osrsbox.items_api.item_equipment import ItemEquipment
 
 PATH_TO_ITEMS_COMPLETE_JSON = Path(__file__).absolute().parent / ".." / ".." / "docs" / "items-complete.json"
 if not PATH_TO_ITEMS_COMPLETE_JSON.is_file():
@@ -125,8 +127,18 @@ class AllItems:
         :raises ValueError: Cannot populate item.
         """
         # Load the item using the ItemDefinition class
+        if item_json["weapon"]:
+            constructor = ItemWeapon.from_json
+        elif item_json["equipable_by_player"]:
+            del item_json["weapon"]
+            constructor = ItemEquipment.from_json
+        else:
+            del item_json["weapon"]
+            del item_json["equipment"]
+            constructor = ItemDefinition.from_json
+
         try:
-            item_def = ItemDefinition.from_json(item_json)
+            item_def = constructor(item_json)
         except TypeError as e:
             raise ValueError("Error: Invalid JSON structure found, check supplied input. Exiting") from e
 

--- a/osrsbox/items_api/item_definition.py
+++ b/osrsbox/items_api/item_definition.py
@@ -24,9 +24,6 @@ import json
 from dataclasses import dataclass, asdict
 from typing import Dict, Optional
 
-from osrsbox.items_api.item_equipment import ItemEquipment
-from osrsbox.items_api.item_weapon import ItemWeapon
-
 
 @dataclass
 class ItemDefinition:
@@ -59,21 +56,12 @@ class ItemDefinition:
     release_date: Optional[str]
     examine: Optional[str]
     url: Optional[str]
-    equipment: Optional[ItemEquipment] = None
-    weapon: Optional[ItemWeapon] = None
 
     @classmethod
-    def from_json(cls, json_dict: Dict) -> "ItemDefinition":
-        """Convert the dictionary under the 'equipment' key into actual :class:`ItemEquipment`"""
-        if json_dict.get("equipable_by_player"):
-            equipment = json_dict.pop("equipment")
-            json_dict["equipment"] = ItemEquipment(**equipment)
-
-        if json_dict.get("weapon"):
-            weapon = json_dict.pop("weapon")
-            json_dict["weapon"] = ItemWeapon(**weapon)
-
-        return cls(**json_dict)
+    def from_json(cls, json_dict):
+        return cls(
+            **json_dict
+        )
 
     def construct_json(self) -> Dict:
         """Construct dictionary/JSON for exporting or printing.

--- a/osrsbox/items_api/item_equipment.py
+++ b/osrsbox/items_api/item_equipment.py
@@ -18,12 +18,13 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ###############################################################################
 """
+from osrsbox.items_api.item_definition import ItemDefinition
 from dataclasses import dataclass, asdict
 from typing import Dict, Optional
 
 
 @dataclass
-class ItemEquipment:
+class ItemEquipment(ItemDefinition):
     """This class defines the properties for an equipable OSRS item.
 
     The ItemEquipment class is the object that retains all items properties related
@@ -47,6 +48,14 @@ class ItemEquipment:
     prayer: int
     slot: str
     requirements: Optional[Dict]
+
+    @classmethod
+    def from_json(cls, json_dict):
+        equipment = json_dict.pop("equipment")
+        return cls(
+            **json_dict,
+            **equipment,
+        )
 
     def construct_json(self) -> Dict:
         """Construct dictionary/JSON of item_equipment property for exporting or printing.

--- a/osrsbox/items_api/item_weapon.py
+++ b/osrsbox/items_api/item_weapon.py
@@ -18,13 +18,14 @@ You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ###############################################################################
 """
-
+from osrsbox.items_api.item_equipment import ItemEquipment
+from osrsbox.items_api.stance import Stance
 from dataclasses import dataclass, asdict
 from typing import List, Dict
 
 
 @dataclass
-class ItemWeapon:
+class ItemWeapon(ItemEquipment):
     """This class defines the properties for an equipable OSRS item that is a weapon.
 
     The ItemWeapon class is the object that retains all items properties related
@@ -34,6 +35,18 @@ class ItemWeapon:
     attack_speed: int
     weapon_type: str
     stances: List
+
+    @classmethod
+    def from_json(cls, json_dict):
+        weapon = json_dict.pop("weapon")
+        stances_json = weapon.pop("stances")
+        item_equipment = json_dict.pop("equipment")
+        return cls(
+            **json_dict,
+            **item_equipment,
+            **weapon,
+            stances=[Stance.from_json(stance) for stance in stances_json],
+        )
 
     def construct_json(self) -> Dict:
         """Construct dictionary/JSON of item_equipment property for exporting or printing.

--- a/osrsbox/items_api/stance.py
+++ b/osrsbox/items_api/stance.py
@@ -1,0 +1,43 @@
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+
+class AttackType(Enum):
+    STAB = "stab"
+    MAGIC = "magic"
+    DEFENSIVE_CASTING = "defensive casting"
+    SLASH = "slash"
+    RANGED = "ranged"
+    SPELLCASTING = "spellcasting"
+    CRUSH = "crush"
+    NONE = None
+    ALIAS_FOR_NONE = "none"
+
+
+class AttackStyle(Enum):
+    ACCURATE = "accurate"
+    AGGRESSIVE = "aggressive"
+    MAGIC = "magic"
+    DEFENSIVE = "defensive"
+    CONTROLLED = "controlled"
+    NONE = None
+    ALIAS_FOR_NONE = "none"
+
+
+@dataclass
+class Stance:
+    boosts: Optional[str]
+    combat_style: str
+    experience: str
+
+    attack_type: AttackType
+    attack_style: AttackStyle
+
+    @classmethod
+    def from_json(cls, json_dict):
+        return cls(
+            attack_type=AttackType(json_dict.pop("attack_type")),
+            attack_style=AttackStyle(json_dict.pop("attack_style")),
+            **json_dict
+        )


### PR DESCRIPTION
As discussed in #102 these changes convert the existing classes into something that is more OO and removes some redundant data if it is not necessary.

The hierarchy is as follows:

`ItemDefinition` is the base class, all items will have these attributes.
`ItemEquipment` is for all equipable items, equipable items will have these attributes and the attributes in `ItemDefinition`.
`ItemWeapon` is for all weapons which will include stances and contains all attributes from `ItemEquipment`.

I've also created a `Stance` class which contains the enums I described.

Note: `_load_item` works as a Factory, understanding which objects to create.