### PR TITLE
Errors when installing requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ attrs==19.3.0
 Cerberus==1.3.2
 certifi==2020.6.20
 chardet==3.0.4
-dataclasses==0.7
+dataclasses==0.7; python_version < "3.7"
 dateparser==0.7.6
 deepdiff==5.0.1
 entrypoints==0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,7 +15,6 @@ more-itertools==8.4.0
 mwparserfromhell==0.5.4
 ordered-set==4.0.2
 packaging==20.4
-pkg-resources==0.0.0
 pluggy==0.13.1
 py==1.9.0
 pycodestyle==2.6.0


### PR DESCRIPTION
### Environment
Windows 10 64 bit
Python 3.7.8

### Issues
Received a few errors while I was installing the requirements in a fresh venv.

![image](https://user-images.githubusercontent.com/61438495/88491085-43db0200-cf6e-11ea-8b00-2d8cd4f03840.png)
Missing environment marker for dataclasses package, only necessary for python version < 3.7.

![image](https://user-images.githubusercontent.com/61438495/88491092-5a815900-cf6e-11ea-91bf-58fdf128fa45.png)
Refer to issue https://github.com/pypa/pip/issues/4022.

### Solution
Added environment marker to dataclasses package in requirements.txt for Python < 3.7.
Removed pkg-resources from requirements.txt.

### Results

```
(.venv) D:\repos\osrsbox-db>python -m pytest test
========================================== test session starts =========================================== 
platform win32 -- Python 3.7.8, pytest-5.4.3, py-1.9.0, pluggy-0.13.1
rootdir: D:\repos\osrsbox-db
collected 9 items                                                                                          

test\test_items_api.py ..                                                                           [ 22%] 
test\test_items_database.py .                                                                       [ 33%] 
test\test_monsters_api.py ..                                                                        [ 55%] 
test\test_monsters_database.py .                                                                    [ 66%] 
test\test_prayers_api.py ..                                                                         [ 88%] 
test\test_prayers_database.py .                                                                     [100%] 

===================================== 9 passed in 151.83s (0:02:31) ======================================
```

Able to successfully install all requirements from requirements.txt and passes all tests.

