### PR TITLE
Fixed monster id conflicts in data/monsters/monsters-wiki-page-text-processed.json

### DIFF
--- a/scripts/wiki/wikitext_parser.py
+++ b/scripts/wiki/wikitext_parser.py
@@ -314,9 +314,8 @@ class WikitextTemplateParser:
                 value = value.strip()
                 return value
             except ValueError:
-                version_key = "version" + version
                 try:
-                    value = self.template.get(version_key).value
+                    value = self.template.get('id').value
                     value = value.strip()
                     return value
                 except ValueError:


### PR DESCRIPTION
Fixed monster id conflicts in data/monsters/monsters-wiki-page-text-processed.json

that file is in gitignore

did not manage to run the script to update /docs/monsters-json files where I originally saw the problem of molanisk being  wrongfully merged with undead zealot.

Assuming the script generating those individual files uses data/monsters/monsters-wiki-page-text-processed.json, that should be fixed.

![Resulting line in processed.json, molanisk is now here](https://user-images.githubusercontent.com/43907476/115978862-6e370b80-a550-11eb-9a4d-105bc5da0273.png)

![Resulting processed.json, undead zealot now has the right id](https://user-images.githubusercontent.com/43907476/115978896-90308e00-a550-11eb-9ccf-e596a93ce100.png)

There is still a problem, undead zealots have ids 10591 & 10592, feel free to reject the PR based on that fact, 10592 is missing from the processed JSON, not all duplicte IDS are missing though, there  is a triple try catch when finding the ID and only those that reach the 3rd try will use my "patch", leading to this problem, I think it's a smaller issue than previously though, I'm not sure what most users expect when using the JSON files but I think avoiding conflicts with IDs is pretty good.
